### PR TITLE
gemspec: Explicit files list

### DIFF
--- a/optparse.gemspec
+++ b/optparse.gemspec
@@ -22,11 +22,7 @@ Gem::Specification.new do |spec|
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = spec.homepage
 
-  spec.files         = Dir.chdir(File.expand_path('..', __FILE__)) do
-    `git ls-files -z`.split("\x0").reject { |f|
-      f.match(%r{\A(?:(?:test|spec|features)/|Gemfile|\.(?:editor|git))})
-    }
-  end
+  spec.files         = Dir["lib/**/*.rb"] + %w[README.md ChangeLog COPYING]
   spec.bindir        = "exe"
   spec.executables   = []
   spec.require_paths = ["lib"]

--- a/optparse.gemspec
+++ b/optparse.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = spec.homepage
 
-  spec.files         = Dir["lib/**/*.rb"] + %w[README.md ChangeLog COPYING]
+  spec.files         = Dir["{doc,lib,misc}/**/*"] + %w[README.md ChangeLog COPYING]
   spec.bindir        = "exe"
   spec.executables   = []
   spec.require_paths = ["lib"]


### PR DESCRIPTION
This avoid shelling out, and includes a narrower list of files.

**Question for reviewer:** did not make a direct commit, since I was curious to know whether the `ChangeLog` file should be included in the distribution or not.