### PR TITLE
Fix `URI#parse` example link

### DIFF
--- a/doc/optparse/argument_converters.rdoc
+++ b/doc/optparse/argument_converters.rdoc
@@ -91,8 +91,8 @@ Executions:
 
   $ ruby uri.rb --uri https://github.com
   [#<URI::HTTPS https://github.com>, URI::HTTPS]
-  $ ruby uri.rb --uri http://github.com
-  [#<URI::HTTP http://github.com>, URI::HTTP]
+  $ ruby uri.rb --uri https://github.com
+  [#<URI::HTTP https://github.com>, URI::HTTP]
   $ ruby uri.rb --uri file://~/var
   [#<URI::File file://~/var>, URI::File]
 


### PR DESCRIPTION
Some GitHub link prefix was `http://` in `doc/optparse/argument_converters.rdoc`(`URI#parse` example).
These link prefix replace to `https://` in this pull request.