### PR TITLE
Also accept '-' as an optional argument

### DIFF
--- a/lib/optparse.rb
+++ b/lib/optparse.rb
@@ -765,15 +765,15 @@ class OptionParser
     end
 
     #
-    # Switch that takes an argument, which does not begin with '-'.
+    # Switch that takes an argument, which does not begin with '-' or is '-'.
     #
     class PlacedArgument < self
 
       #
-      # Returns nil if argument is not present or begins with '-'.
+      # Returns nil if argument is not present or begins with '-' and is not '-'.
       #
       def parse(arg, argv, &error)
-        if !(val = arg) and (argv.empty? or /\A-/ =~ (val = argv[0]))
+        if !(val = arg) and (argv.empty? or /\A-./ =~ (val = argv[0]))
           return nil, block, nil
         end
         opt = (val = parse_arg(val, &error))[1]

--- a/test/optparse/test_placearg.rb
+++ b/test/optparse/test_placearg.rb
@@ -18,6 +18,8 @@ class TestOptionParserPlaceArg < TestOptionParser
   def test_short
     assert_equal(%w"", no_error {@opt.parse!(%w"-x -n")})
     assert_equal(nil, @flag)
+    assert_equal(%w"", no_error {@opt.parse!(%w"-x -")})
+    assert_equal("-", @flag)
     @flag = false
     assert_equal(%w"", no_error {@opt.parse!(%w"-x foo")})
     assert_equal("foo", @flag)
@@ -30,6 +32,8 @@ class TestOptionParserPlaceArg < TestOptionParser
   def test_abbrev
     assert_equal(%w"", no_error {@opt.parse!(%w"-o -n")})
     assert_equal(nil, @flag)
+    assert_equal(%w"", no_error {@opt.parse!(%w"-o -")})
+    assert_equal("-", @flag)
     @flag = false
     assert_equal(%w"", no_error {@opt.parse!(%w"-o foo")})
     assert_equal("foo", @flag)
@@ -42,6 +46,8 @@ class TestOptionParserPlaceArg < TestOptionParser
   def test_long
     assert_equal(%w"", no_error {@opt.parse!(%w"--opt -n")})
     assert_equal(nil, @flag)
+    assert_equal(%w"", no_error {@opt.parse!(%w"--opt -")})
+    assert_equal("-", @flag)
     assert_equal(%w"foo", no_error {@opt.parse!(%w"--opt= foo")})
     assert_equal("", @flag)
     assert_equal(%w"", no_error {@opt.parse!(%w"--opt=foo")})


### PR DESCRIPTION
A single dash is already recognized as a non-option argument when not specified as an argument to an option, but it isn't when it is.  This change corrects it.
