### PR TITLE
Don't treat empty string as an option description

### DIFF
--- a/lib/optparse.rb
+++ b/lib/optparse.rb
@@ -1502,7 +1502,7 @@ XXX
         style = notwice(default_style.guess(arg = o), style, 'style')
         default_pattern, conv = search(:atype, Object) unless default_pattern
       else
-        desc.push(o)
+        desc.push(o) if o && !o.empty?
       end
     end
 

--- a/test/optparse/test_summary.rb
+++ b/test/optparse/test_summary.rb
@@ -68,7 +68,6 @@ class TestOptionParserSummaryTest < TestOptionParser
     end
 
     s = o.summarize
-    puts s
 
     assert_match(/^\s*--long-long-option-param-without-short$/, s[0])
     assert_match(/^\s*Error desc$/, s[1])

--- a/test/optparse/test_summary.rb
+++ b/test/optparse/test_summary.rb
@@ -55,4 +55,28 @@ class TestOptionParserSummaryTest < TestOptionParser
     o.release = "rel"
     assert_equal "foo 0.1 (rel)", o.ver
   end
+
+  # https://github.com/ruby/optparse/issues/37
+  def test_very_long_without_short
+    o = OptionParser.new do |opts|
+      # This causes TypeError
+      opts.on('',   '--long-long-option-param-without-short', "Error desc") { options[:long_long_option_param_without_short] = true }
+      opts.on('',   '--long-option-param', "Long desc") { options[:long_option_param_without_short] = true }
+      opts.on('-a', '--long-long-option-param-with-short', "Normal description") { options[:long_long_option_param_with_short] = true }
+
+      opts.on('',   '--long-long-option-param-without-short-but-with-desc', 'Description of the long long param') { options[:long_long_option_param_without_short_but_with_desc] = true }
+    end
+
+    s = o.summarize
+    puts s
+
+    assert_match(/^\s*--long-long-option-param-without-short$/, s[0])
+    assert_match(/^\s*Error desc$/, s[1])
+    assert_match(/^\s*--long-option-param\s+Long desc$/, s[2])
+    assert_match(/^\s*-a\s+Normal description$/, s[3])
+    assert_match(/^\s*--long-long-option-param-with-short$/, s[4])
+
+    assert_match(/^\s*--long-long-option-param-without-short-but-with-desc$/, s[5])
+    assert_match(/^\s*Description of the long long param$/, s[6])
+  end
 end


### PR DESCRIPTION
Fixes https://github.com/ruby/optparse/issues/37.

When an empty stirng was parsed in `make_switch`, it was treated as a part of the option description (and pushed to `desc`). When this array was then used to print options summary, it caused issues for options with missing short version and very long long version (longer than `width`).

In the final `while` of `Switch#summarize`, a `nil` was assigned to `left` and it wasn't converted to string, because `right` was an empty string: https://github.com/ruby/optparse/blob/master/lib/optparse.rb#L633. and an error was raised.

### Tests

Tested manually with `test.rb placed in the main dir of the gem: 
```ruby
require_relative 'lib/optparse'

options = {}
o = OptionParser.new do |opts|
  # These options are fine.
  opts.on('',   '--long-option-param', "Long no argument description") { options[:long_option_param_without_short] = true }
  opts.on('-a', '--long-long-option-param-with-short', "Long, very long description, running low and high, a long, long description." * 10) { options[:long_long_option_param_with_short] = true }
  opts.on('-b',   '--normal-option-param', "Short no argument description") { options[:long_option_param_without_short] = true }

  # This caused TypeError
  opts.on('',   '--long-long-option-param-without-short') { options[:long_long_option_param_without_short] = true }

  # Test options for empty description
  opts.on('',   '--long-long-option-param-without-short-but-with-desc', 'Description of the long long param') { options[:long_long_option_param_without_short_but_with_desc] = true }
  opts.on('-s', '--short') { options[:short] = true }
  opts.on('-S', '') { options[:shorter] = true }
  opts.on('', '--no-desc') { options[:no_desc] = true }
  opts.on('', '--empty-desc', '') { options[:empty_desc] = true }
  opts.on('', '--no-short-desc', 'No short desc') { options[:empty_desc] = true }
  opts.on('-n', '--normal', "A normal option with a description") { options[:normal] = true }
end

puts o.summarize
```
With the result of:
```
$ ruby test.rb 
        --long-option-param          Long no argument description
    -a                               Long, very long description, running low and high, a long, long description.Long, very long description, running low and high, a long, long description.Long, very long description, running low and high, a long, long description.Long, very long description, running low and high, a long, long description.Long, very long description, running low and high, a long, long description.Long, very long description, running low and high, a long, long description.Long, very long description, running low and high, a long, long description.Long, very long description, running low and high, a long, long description.Long, very long description, running low and high, a long, long description.Long, very long description, running low and high, a long, long description.
        --long-long-option-param-with-short
    -b, --normal-option-param        Short no argument description
        --long-long-option-param-without-short
        --long-long-option-param-without-short-but-with-desc
                                     Description of the long long param
    -s, --short
    -S
        --no-desc
        --empty-desc
        --no-short-desc              No short desc
    -n, --normal                     A normal option with a description

```

### Alternative solutions

I've also tried to call `to_s` on the `l` variable in the place that was causing the error:
```diff
-        yield(indent + l)
+        yield(indent + l.to_s)
```

but I ended up with having misaligned description for shorter long options with the short option, i.e.
```
        --no-short-desc
                                     No short desc

```
instead of 
```
        --no-short-desc              No short desc
```
 
