### PR TITLE
#load() into hash

### DIFF
--- a/lib/optparse.rb
+++ b/lib/optparse.rb
@@ -1903,6 +1903,9 @@ XXX
   # directory ~/.options, then the basename with '.options' suffix
   # under XDG and Haiku standard places.
   #
+  # The optional +into+ keyword argument works exactly like that accepted in
+  # method #parse
+  #
   def load(filename = nil, into: nil)
     unless filename
       basename = File.basename($0, '.*')

--- a/lib/optparse.rb
+++ b/lib/optparse.rb
@@ -1904,7 +1904,7 @@ XXX
   # under XDG and Haiku standard places.
   #
   # The optional +into+ keyword argument works exactly like that accepted in
-  # method #parse
+  # method #parse.
   #
   def load(filename = nil, into: nil)
     unless filename

--- a/lib/optparse.rb
+++ b/lib/optparse.rb
@@ -1903,10 +1903,10 @@ XXX
   # directory ~/.options, then the basename with '.options' suffix
   # under XDG and Haiku standard places.
   #
-  def load(filename = nil)
+  def load(filename = nil, into: nil)
     unless filename
       basename = File.basename($0, '.*')
-      return true if load(File.expand_path(basename, '~/.options')) rescue nil
+      return true if load(File.expand_path(basename, '~/.options'), into: into) rescue nil
       basename << ".options"
       return [
         # XDG
@@ -1918,11 +1918,11 @@ XXX
         '~/config/settings',
       ].any? {|dir|
         next if !dir or dir.empty?
-        load(File.expand_path(basename, dir)) rescue nil
+        load(File.expand_path(basename, dir), into: into) rescue nil
       }
     end
     begin
-      parse(*IO.readlines(filename).each {|s| s.chomp!})
+      parse(*IO.readlines(filename).each {|s| s.chomp!}, into: into)
       true
     rescue Errno::ENOENT, Errno::ENOTDIR
       false


### PR DESCRIPTION
I'm trying to use `OptionParser` in my personal scripts. I'd like to parse arguments both from config file and ARGV. Ideally I want to just [write code like this](https://github.com/5long/dotfiles/blob/ea81f15526f98a0768fc7f90db10a7cf28be1536/bin/lte#L107-L112) which doesn't work yet. But it certainly feels "right" to have a consistent interface of accepting the keyword argument `into: {}` among `#parse`, `#order` and `#load`.

Thus this pull request.