### PR TITLE
Remove some dead headings in RDocs

### DIFF
--- a/doc/optparse/option_params.rdoc
+++ b/doc/optparse/option_params.rdoc
@@ -31,7 +31,6 @@ Contents:
     - {Long Names with Optional Arguments}[#label-Long+Names+with+Optional+Arguments]
     - {Long Names with Negation}[#label-Long+Names+with+Negation]
   - {Mixed Names}[#label-Mixed+Names]
-- {Argument Styles}[#label-Argument+Styles]
 - {Argument Values}[#label-Argument+Values]
   - {Explicit Argument Values}[#label-Explicit+Argument+Values]
     - {Explicit Values in Array}[#label-Explicit+Values+in+Array]

--- a/doc/optparse/tutorial.rdoc
+++ b/doc/optparse/tutorial.rdoc
@@ -42,7 +42,6 @@ The class also has method #help, which displays automatically-generated help tex
   - {Option with No Argument}[#label-Option+with+No+Argument]
   - {Option with Required Argument}[#label-Option+with+Required+Argument]
   - {Option with Optional Argument}[#label-Option+with+Optional+Argument]
-  - {Argument Abbreviations}[#label-Argument+Abbreviations]
 - {Argument Values}[#label-Argument+Values]
   - {Explicit Argument Values}[#label-Explicit+Argument+Values]
     - {Explicit Values in Array}[#label-Explicit+Values+in+Array]


### PR DESCRIPTION
Looks like some great work adding docs by https://github.com/BurdetteLamar, but found two small headings that appeared to be just leftover anchor links in the Tutorial and Option Params document.