### PR TITLE
Fix `require_exact` to work with options defined as `--[no]-something`

### DIFF
--- a/lib/optparse.rb
+++ b/lib/optparse.rb
@@ -1048,7 +1048,7 @@ XXX
   # Shows option summary.
   #
   Officious['help'] = proc do |parser|
-    Switch::NoArgument.new do |arg|
+    Switch::NoArgument.new(nil, nil, ["-h"], ["--help"]) do |arg|
       puts parser.help
       exit
     end
@@ -1466,7 +1466,7 @@ XXX
           default_style = default_style.guess(arg = a)
           default_pattern, conv = search(:atype, o) unless default_pattern
         end
-        ldesc << "--[no-]#{q}"
+        ldesc << "--#{q}" << "--no-#{q}"
         (o = q.downcase).tr!('_', '-')
         long << o
         not_pattern, not_conv = search(:atype, FalseClass) unless not_style
@@ -1642,7 +1642,7 @@ XXX
           opt.tr!('_', '-')
           begin
             sw, = complete(:long, opt, true)
-            if require_exact && !sw.long.include?(arg)
+            if require_exact && !sw.long.include?("--#{opt}")
               throw :terminate, arg unless raise_unknown
               raise InvalidOption, arg
             end

--- a/test/optparse/test_optparse.rb
+++ b/test/optparse/test_optparse.rb
@@ -88,9 +88,9 @@ class TestOptionParser < Test::Unit::TestCase
     end
 
     @opt.require_exact = true
-    %w(--zrs -F -Ffoo).each do |arg|
+    [%w(--zrs foo), %w(--zrs=foo), %w(-F foo), %w(-Ffoo)].each do |args|
       result = {}
-      @opt.parse([arg, 'foo'], into: result)
+      @opt.parse(args, into: result)
       assert_equal({zrs: 'foo'}, result)
     end
 
@@ -99,6 +99,14 @@ class TestOptionParser < Test::Unit::TestCase
     assert_raise(OptionParser::InvalidOption) {@opt.parse(%w(-zrs foo))}
     assert_raise(OptionParser::InvalidOption) {@opt.parse(%w(-zr foo))}
     assert_raise(OptionParser::InvalidOption) {@opt.parse(%w(-z foo))}
+
+    @opt.def_option('-f', '--[no-]foo', 'foo') {|arg| @foo = arg}
+    @opt.parse(%w[-f])
+    assert_equal(true, @foo)
+    @opt.parse(%w[--foo])
+    assert_equal(true, @foo)
+    @opt.parse(%w[--no-foo])
+    assert_equal(false, @foo)
   end
 
   def test_raise_unknown


### PR DESCRIPTION
While working on https://github.com/rubocop/rubocop/pull/12282 I identified that `optparse` does not work correctly when `require_exact` is set and an option with `--[no-]` prefix is defined. It raises `invalid option` when this option is provided via command line.

Example
```ruby
OptionParser.new do |opts|
  opts.require_exact = true

  opts.on("-v", "--[no-]verbose", "Run verbosely") do
    # ...
  end
end
```

```bash
$ cli --verbose
invalid option: --verbose
For usage information, use --help
```

This config was introduced in https://github.com/ruby/optparse/pull/2.
cc @jeremyevans (as implementor)