### PR TITLE
Fix parsing array arguments with `:into` option

### DIFF
--- a/lib/optparse.rb
+++ b/lib/optparse.rb
@@ -1729,9 +1729,9 @@ XXX
             end
           end
           begin
-            opt, cb, *val = sw.parse(rest, argv) {|*exc| raise(*exc)}
-            val = callback!(cb, 1, *val) if cb
-            callback!(setter, 2, sw.switch_name, *val) if setter
+            opt, cb, val = sw.parse(rest, argv) {|*exc| raise(*exc)}
+            val = callback!(cb, 1, val) if cb
+            callback!(setter, 2, sw.switch_name, val) if setter
           rescue ParseError
             raise $!.set_option(arg, rest)
           end
@@ -1761,7 +1761,7 @@ XXX
             raise $!.set_option(arg, true)
           end
           begin
-            opt, cb, *val = sw.parse(val, argv) {|*exc| raise(*exc) if eq}
+            opt, cb, val = sw.parse(val, argv) {|*exc| raise(*exc) if eq}
           rescue ParseError
             raise $!.set_option(arg, arg.length > 2)
           else
@@ -1769,8 +1769,8 @@ XXX
           end
           begin
             argv.unshift(opt) if opt and (!rest or (opt = opt.sub(/\A-*/, '-')) != '-')
-            val = callback!(cb, 1, *val) if cb
-            callback!(setter, 2, sw.switch_name, *val) if setter
+            val = callback!(cb, 1, val) if cb
+            callback!(setter, 2, sw.switch_name, val) if setter
           rescue ParseError
             raise $!.set_option(arg, arg.length > 2)
           end
@@ -1798,6 +1798,8 @@ XXX
 
   # Calls callback with _val_.
   def callback!(cb, max_arity, *args) # :nodoc:
+    args.compact!
+
     if (size = args.size) < max_arity and cb.to_proc.lambda?
       (arity = cb.arity) < 0 and arity = (1-arity)
       arity = max_arity if arity > max_arity

--- a/test/optparse/test_acceptable.rb
+++ b/test/optparse/test_acceptable.rb
@@ -199,5 +199,7 @@ class TestOptionParserAcceptable < TestOptionParser
   def test_array
     assert_equal(%w"", no_error {@opt.parse!(%w"--array a,b,c")})
     assert_equal(%w"a b c", @array)
+    assert_equal(%w"", no_error {@opt.parse!(%w"--array a")})
+    assert_equal(%w"a", @array)
   end
 end

--- a/test/optparse/test_optparse.rb
+++ b/test/optparse/test_optparse.rb
@@ -91,6 +91,12 @@ class TestOptionParser < Test::Unit::TestCase
     result = {}
     @opt.parse %w(--array b,c,d), into: result
     assert_equal({array: %w(b c d)}, result)
+    result = {}
+    @opt.parse %w(-a b), into: result
+    assert_equal({array: %w(b)}, result)
+    result = {}
+    @opt.parse %w(--array b), into: result
+    assert_equal({array: %w(b)}, result)
   end
 
   def test_require_exact

--- a/test/optparse/test_optparse.rb
+++ b/test/optparse/test_optparse.rb
@@ -74,6 +74,7 @@ class TestOptionParser < Test::Unit::TestCase
     @opt.def_option "-v", "--verbose" do @verbose = true end
     @opt.def_option "-q", "--quiet" do @quiet = true end
     @opt.def_option "-o", "--option [OPT]" do |opt| @option = opt end
+    @opt.def_option "-a", "--array [VAL]", Array do |val| val end
     result = {}
     @opt.parse %w(--host localhost --port 8000 -v), into: result
     assert_equal({host: "localhost", port: 8000, verbose: true}, result)
@@ -84,6 +85,12 @@ class TestOptionParser < Test::Unit::TestCase
     result = {}
     @opt.parse %w(--option OPTION -v), into: result
     assert_equal({verbose: true, option: "OPTION"}, result)
+    result = {}
+    @opt.parse %w(-a b,c,d), into: result
+    assert_equal({array: %w(b c d)}, result)
+    result = {}
+    @opt.parse %w(--array b,c,d), into: result
+    assert_equal({array: %w(b c d)}, result)
   end
 
   def test_require_exact


### PR DESCRIPTION
Fixes #72.

When we defined an array parameter and use `:into` when parsing, when parsed its value (array) incorrectly gets destructured in https://github.com/ruby/optparse/blob/1211f70b6b73e2f142a5c8158f38359d2d0bc1ef/lib/optparse.rb#L1773 and passed to the callback (aka setter) in https://github.com/ruby/optparse/blob/1211f70b6b73e2f142a5c8158f38359d2d0bc1ef/lib/optparse.rb#L1702 and so we get the ArgumentError. 