### PR TITLE
Enhance to support 'Set' object as an enum

### DIFF
--- a/lib/optparse.rb
+++ b/lib/optparse.rb
@@ -7,6 +7,7 @@
 #
 # See OptionParser for documentation.
 #
+require 'set' unless defined?(Set)
 
 #--
 # == Developer Documentation (not for RDoc output)
@@ -1494,7 +1495,7 @@ XXX
       case o
       when Proc, Method
         block = notwice(o, block, 'block')
-      when Array, Hash
+      when Array, Hash, Set
         case pattern
         when CompletingHash
         when nil


### PR DESCRIPTION
OptionParser supports Array and Hash object as an enum of option value.
But Set object is not supported.
For example:

```ruby
require 'optparse'

parser = OptionParser.new
parser.on("--lang1=<lang>", ["en", "fr", "it"])   # option value will be checked by enum values
parser.on("--lang2=<lang>", Set.new(["en", "fr", "it"]))   # will not be checked when Set object

opts = {}
parser.parse(["--lang2", "ja"], into: opts)   # !!! not raise error !!!
parser.parse(["--lang1", "ja"], into: opts)   # raises error expectedly
p opts
```

Since Ruby 3.2, Set class is a built-in class.
I think that it is very natural for OptionParser to support Set object.

By the way, I can't find a test script to test `OptionParser#make_switch()` method.
Therefore this pull request doesn't contain any test case.