### PR TITLE
Backport from v0.5.0 to fix a bug #74

### DIFF
--- a/lib/optparse.rb
+++ b/lib/optparse.rb
@@ -1641,14 +1641,19 @@ XXX
           opt, rest = $1, $2
           opt.tr!('_', '-')
           begin
-            sw, = complete(:long, opt, true)
-            if require_exact && !sw.long.include?(arg)
-              throw :terminate, arg unless raise_unknown
-              raise InvalidOption, arg
+            if require_exact
+              sw, = search(:long, opt)
+            else
+              sw, = complete(:long, opt, true)
             end
           rescue ParseError
             throw :terminate, arg unless raise_unknown
             raise $!.set_option(arg, true)
+          else
+            unless sw
+              throw :terminate, arg unless raise_unknown
+              raise InvalidOption, arg
+            end
           end
           begin
             opt, cb, val = sw.parse(rest, argv) {|*exc| raise(*exc)}

--- a/test/optparse/test_optparse.rb
+++ b/test/optparse/test_optparse.rb
@@ -120,4 +120,16 @@ class TestOptionParser < Test::Unit::TestCase
     e = assert_raise(OptionParser::InvalidOption) {@opt.parse(%w(-t))}
     assert_equal(["-t"], e.args)
   end
+
+  def test_default_help_option  # bug #74
+    @opt.require_exact = true       # !!!
+    sout, serr = capture_output() do
+      assert_raise(SystemExit) do
+        @opt.parse!(["--help"])
+      end
+    end
+    assert_empty(serr)
+    assert_match(/\AUsage: \w+ \[options\]\n\z/, sout)
+  end
+
 end


### PR DESCRIPTION
Bug #74 seems to be fixed on v0.5.0, but Ruby 3.3 bundles v0.4.0.
Therefore it is recommended to backport the bugfix to v0.4.0.