### PR TITLE
Fix `LESS` environment variable setup in `OptionParser#help_exit`

### DIFF
--- a/lib/optparse.rb
+++ b/lib/optparse.rb
@@ -1053,7 +1053,7 @@ XXX
   def help_exit
     if STDOUT.tty? && (pager = ENV.values_at(*%w[RUBY_PAGER PAGER]).find {|e| e && !e.empty?})
       less = ENV["LESS"]
-      args = [{"LESS" => "#{!less || less.empty? ? '-' : less}Fe"}, pager, "w"]
+      args = [{"LESS" => "#{less} -Fe"}, pager, "w"]
       print = proc do |f|
         f.puts help
       rescue Errno::EPIPE


### PR DESCRIPTION
If the original value of `LESS` ends with an option starting with `--`, simply appending `Fe` would result in an invalid option string.

```
% LESS=--RAW-CONTROL-CHARS ruby -roptparse -e 'OptionParser.new.parse(ARGV)' -- --help
There is no RAW-CONTROL-CHARSFe option ("less --help" for help)
Press RETURN to continue
```

As far as I have tested, it seems that `LESS` can safely contain preceding spaces.