### PR TITLE
Fix completion of key-value pairs array

### DIFF
--- a/lib/optparse.rb
+++ b/lib/optparse.rb
@@ -1502,7 +1502,7 @@ XXX
         block = notwice(o, block, 'block')
       when Array, Hash
         if Array === o
-          o, v = o.partition {|v| Completion.completable?(v)}
+          o, v = o.partition {|v,| Completion.completable?(v)}
           values = notwice(v, values, 'values') unless v.empty?
           next if o.empty?
         end

--- a/test/optparse/test_placearg.rb
+++ b/test/optparse/test_placearg.rb
@@ -8,6 +8,7 @@ class TestOptionParserPlaceArg < TestOptionParser
     @opt.def_option("--option [VAL]") {|x| @flag = x}
     @opt.def_option("-T [level]", /^[0-4]$/, Integer) {|x| @topt = x}
     @opt.def_option("--enum [VAL]", [:Alpha, :Bravo, :Charlie]) {|x| @enum = x}
+    @opt.def_option("--enumval [VAL]", [[:Alpha, 1], [:Bravo, 2], [:Charlie, 3]]) {|x| @enum = x}
     @opt.def_option("--integer [VAL]", Integer, [1, 2, 3]) {|x| @integer = x}
     @opt.def_option("--range [VAL]", Integer, 1..3) {|x| @range = x}
     @topt = nil
@@ -100,6 +101,11 @@ class TestOptionParserPlaceArg < TestOptionParser
   def test_enum
     assert_equal([], no_error {@opt.parse!(%w"--enum=A")})
     assert_equal(:Alpha, @enum)
+  end
+
+  def test_enum_pair
+    assert_equal([], no_error {@opt.parse!(%w"--enumval=A")})
+    assert_equal(1, @enum)
   end
 
   def test_enum_conversion


### PR DESCRIPTION
Enum array may be the list of pairs of key and value.  Check if only key is completable, not pair.

Fix #93
Fix #94