### PR TITLE
Expand literal home paths only

### DIFF
--- a/lib/optparse.rb
+++ b/lib/optparse.rb
@@ -2047,19 +2047,21 @@ XXX
   def load(filename = nil, **keywords)
     unless filename
       basename = File.basename($0, '.*')
-      return true if load(File.expand_path(basename, '~/.options'), **keywords) rescue nil
+      return true if load(File.expand_path("~/.options/#{basename}"), **keywords) rescue nil
       basename << ".options"
       return [
         # XDG
         ENV['XDG_CONFIG_HOME'],
-        '~/.config',
+        ['~/.config', true],
         *ENV['XDG_CONFIG_DIRS']&.split(File::PATH_SEPARATOR),
 
         # Haiku
-        '~/config/settings',
-      ].any? {|dir|
+        ['~/config/settings', true],
+      ].any? {|dir, expand|
         next if !dir or dir.empty?
-        load(File.expand_path(basename, dir), **keywords) rescue nil
+        filename = File.join(dir, basename)
+        filename = File.expand_path(filename) if expand
+        load(filename, **keywords) rescue nil
       }
     end
     begin

--- a/test/optparse/test_load.rb
+++ b/test/optparse/test_load.rb
@@ -31,7 +31,13 @@ class TestOptionParserLoad < Test::Unit::TestCase
     assert_equal({test: result}, into)
   end
 
+  def assert_load_nothing
+    assert !new_parser.load
+    assert_nil @result
+  end
+
   def setup_options(env, dir, suffix = nil)
+    env.update({'HOME'=>@tmpdir})
     optdir = File.join(@tmpdir, dir)
     FileUtils.mkdir_p(optdir)
     file = File.join(optdir, [@basename, suffix].join(""))
@@ -50,7 +56,7 @@ class TestOptionParserLoad < Test::Unit::TestCase
   end
 
   def setup_options_home(&block)
-    setup_options({'HOME'=>@tmpdir}, ".options", &block)
+    setup_options({}, ".options", &block)
   end
 
   def setup_options_xdg_config_home(&block)
@@ -58,7 +64,7 @@ class TestOptionParserLoad < Test::Unit::TestCase
   end
 
   def setup_options_home_config(&block)
-    setup_options({'HOME'=>@tmpdir}, ".config", ".options", &block)
+    setup_options({}, ".config", ".options", &block)
   end
 
   def setup_options_xdg_config_dirs(&block)
@@ -66,7 +72,7 @@ class TestOptionParserLoad < Test::Unit::TestCase
   end
 
   def setup_options_home_config_settings(&block)
-    setup_options({'HOME'=>@tmpdir}, "config/settings", ".options", &block)
+    setup_options({}, "config/settings", ".options", &block)
   end
 
   def test_load_home_options
@@ -135,7 +141,8 @@ class TestOptionParserLoad < Test::Unit::TestCase
   end
 
   def test_load_nothing
-    assert !new_parser.load
-    assert_nil @result
+    setup_options({}, "") do
+      assert_load_nothing
+    end
   end
 end

--- a/test/optparse/test_load.rb
+++ b/test/optparse/test_load.rb
@@ -75,6 +75,10 @@ class TestOptionParserLoad < Test::Unit::TestCase
     setup_options({}, "config/settings", ".options", &block)
   end
 
+  def setup_options_home_options(envname, &block)
+    setup_options({envname => '~/options'}, "options", ".options", &block)
+  end
+
   def test_load_home_options
     result, = setup_options_home
     assert_load(result)
@@ -142,6 +146,32 @@ class TestOptionParserLoad < Test::Unit::TestCase
 
   def test_load_nothing
     setup_options({}, "") do
+      assert_load_nothing
+    end
+  end
+
+  def test_not_expand_path_basename
+    basename = @basename
+    @basename = "~"
+    $test_optparse_basename = "/" + @basename
+    alias $test_optparse_prog $0
+    alias $0 $test_optparse_basename
+    setup_options({'HOME'=>@tmpdir+"/~options"}, "", "options") do
+      assert_load_nothing
+    end
+  ensure
+    alias $0 $test_optparse_prog
+    @basename = basename
+  end
+
+  def test_not_expand_path_xdg_config_home
+    setup_options_home_options('XDG_CONFIG_HOME') do
+      assert_load_nothing
+    end
+  end
+
+  def test_not_expand_path_xdg_config_dirs
+    setup_options_home_options('XDG_CONFIG_DIRS') do
       assert_load_nothing
     end
   end


### PR DESCRIPTION
Paths in environment variables should already be expanded.
The base name of the program is also not subject to expansion.
