### PR TITLE
Use `~/.config` only if `$XDG_CONFIG_HOME` is unset or empty

### DIFF
--- a/lib/optparse.rb
+++ b/lib/optparse.rb
@@ -2049,10 +2049,16 @@ XXX
       basename = File.basename($0, '.*')
       return true if load(File.expand_path("~/.options/#{basename}"), **keywords) rescue nil
       basename << ".options"
+      if !(xdg = ENV['XDG_CONFIG_HOME']) or xdg.empty?
+        # https://specifications.freedesktop.org/basedir-spec/latest/#variables
+        #
+        # If $XDG_CONFIG_HOME is either not set or empty, a default
+        # equal to $HOME/.config should be used.
+        xdg = ['~/.config', true]
+      end
       return [
-        # XDG
-        ENV['XDG_CONFIG_HOME'],
-        ['~/.config', true],
+        xdg,
+
         *ENV['XDG_CONFIG_DIRS']&.split(File::PATH_SEPARATOR),
 
         # Haiku

--- a/test/optparse/test_load.rb
+++ b/test/optparse/test_load.rb
@@ -47,7 +47,7 @@ class TestOptionParserLoad < Test::Unit::TestCase
       begin
         yield dir, optdir
       ensure
-        File.unlink(file)
+        File.unlink(file) rescue nil
         Dir.rmdir(optdir) rescue nil
       end
     else
@@ -101,7 +101,7 @@ class TestOptionParserLoad < Test::Unit::TestCase
   end
 
   def test_load_xdg_config_home
-    result, = setup_options_xdg_config_home
+    result, dir = setup_options_xdg_config_home
     assert_load(result)
 
     setup_options_home_config do
@@ -115,6 +115,11 @@ class TestOptionParserLoad < Test::Unit::TestCase
     setup_options_home_config_settings do
       assert_load(result)
     end
+
+    File.unlink("#{dir}/#{@basename}.options")
+    setup_options_home_config do
+      assert_load_nothing
+    end
   end
 
   def test_load_home_config
@@ -127,6 +132,11 @@ class TestOptionParserLoad < Test::Unit::TestCase
 
     setup_options_home_config_settings do
       assert_load(result)
+    end
+
+    setup_options_xdg_config_home do |_, dir|
+      File.unlink("#{dir}/#{@basename}.options")
+      assert_load_nothing
     end
   end
 


### PR DESCRIPTION
https://specifications.freedesktop.org/basedir-spec/latest/#variables
> If `$XDG_CONFIG_HOME` is either not set or empty, a default equal to `$HOME`/.config should be used.
