### PR TITLE
Accept Backtrace::Locations in OptParse::ParseError#set_backtrace

### DIFF
--- a/lib/optparse.rb
+++ b/lib/optparse.rb
@@ -2271,7 +2271,7 @@ XXX
     DIR = File.join(__dir__, '')
     def self.filter_backtrace(array)
       unless $DEBUG
-        array.delete_if {|bt| bt.start_with?(DIR)}
+        array.delete_if {|bt| (bt.respond_to?(:path) ? bt.path : bt).start_with?(DIR)}
       end
       array
     end

--- a/test/optparse/test_optparse.rb
+++ b/test/optparse/test_optparse.rb
@@ -178,6 +178,12 @@ class TestOptionParser < Test::Unit::TestCase
     assert_equal(["-t"], e.args)
   end
 
+  def test_parse_error_set_backtrace
+    e = assert_raise(OptionParser::InvalidOption) {@opt.parse(%w(-t))}
+    assert_nothing_raised {e.set_backtrace(e.backtrace)}
+    assert_nothing_raised {e.set_backtrace(e.backtrace_locations)}
+  end
+
   def test_help_pager
     require 'tmpdir'
     Dir.mktmpdir do |dir|


### PR DESCRIPTION
A caller might pass an Array of Backtrace::Location expecting Exception#set_backtrace to handle it, so we should handle that too.

