### PR TITLE
add an abort: keyword, which lets you abort on failure

### DIFF
--- a/doc/optparse/tutorial.rdoc
+++ b/doc/optparse/tutorial.rdoc
@@ -52,6 +52,7 @@ The class also has method #help, which displays automatically-generated help tex
   - {Collecting Options}[#label-Collecting+Options]
   - {Checking for Missing Options}[#label-Checking+for+Missing+Options]
   - {Default Values for Options}[#label-Default+Values+for+Options]
+- {Keyword Argument abort}[#label-Keyword+Argument+abort]
 - {Argument Converters}[#label-Argument+Converters]
 - {Help}[#label-Help]
 - {Top List and Base List}[#label-Top+List+and+Base+List]
@@ -120,7 +121,7 @@ is with instance method OptionParser#on.
 
 The method may be called with any number of arguments
 (whose order does not matter),
-and may also have a trailing optional keyword argument +into+.
+and may also have trailing optional keyword arguments +into+ and +abort+.
 
 The given arguments determine the characteristics of the new option.
 These may include:
@@ -542,6 +543,12 @@ Executions:
   $ ruby default_values.rb --yyy FOO
   {:yyy=>"FOO", :zzz=>"BBB"}
 
+=== Keyword Argument +abort+
+
+In parsing options, you can add keyword option +abort+ with a boolean. If passed
++true+, any +OptionParser::ParseError+ errors that occur when parsing arguments
+will instead call +OptionParser#abort+ to stop argument processing.
+
 === Argument Converters
 
 An option can specify that its argument is to be converted
@@ -706,6 +713,8 @@ Each of these methods:
   whose initial value is ARGV.
 - Accepts an optional keyword argument +into+
   (see {Keyword Argument into}[#label-Keyword+Argument+into]).
+- Accepts an optional keyword argument +abort+
+  (see {Keyword Argument abort}[#label-Keyword+Argument+abort]).
 - Returns +argv+, possibly with some elements removed.
 
 The three other methods have names _not_ ending with a "bang":
@@ -720,6 +729,8 @@ Each of these methods:
   _or_ zero or more string arguments.
 - Accepts an optional keyword argument +into+ and its value _into_.
   (see {Keyword Argument into}[#label-Keyword+Argument+into]).
+- Accepts an optional keyword argument +abort+.
+  (see {Keyword Argument abort}[#label-Keyword+Argument+abort]).
 - Returns +argv+, possibly with some elements removed.
 
 ==== \Method +parse!+
@@ -731,6 +742,8 @@ Each of these methods:
   whose initial value is ARGV.
 - Accepts an optional keyword argument +into+
   (see {Keyword Argument into}[#label-Keyword+Argument+into]).
+- Accepts an optional keyword argument +abort+
+  (see {Keyword Argument abort}[#label-Keyword+Argument+abort]).
 - Returns +argv+, possibly with some elements removed.
 
 The method processes the elements in +argv+ beginning at <tt>argv[0]</tt>,
@@ -787,6 +800,8 @@ Processing ended by non-option found when +POSIXLY_CORRECT+ is defined:
   _or_ zero or more string arguments.
 - Accepts an optional keyword argument +into+ and its value _into_.
   (see {Keyword Argument into}[#label-Keyword+Argument+into]).
+- Accepts an optional keyword argument +abort+ and a truthy value.
+  (see {Keyword Argument abort}[#label-Keyword+Argument+abort]).
 - Returns +argv+, possibly with some elements removed.
 
 If given an array +ary+, the method forms array +argv+ as <tt>ary.dup</tt>.
@@ -795,7 +810,7 @@ into array +argv+.
 
 The method calls
 
-  parse!(argv, into: into)
+  parse!(argv, into: into, abort: abort)
 
 Note that environment variable +POSIXLY_CORRECT+
 and the terminator argument <tt>--</tt> are honored.

--- a/lib/optparse.rb
+++ b/lib/optparse.rb
@@ -262,6 +262,24 @@ require 'set' unless defined?(Set)
 #   $ ruby optparse-test.rb -a -b 100
 #   {:a=>true, :b=>100}
 #
+# === Aborting on Failure
+#
+# The +abort+ option of +order+, +parse+ and so on methods will call +OptionParser#abort+ on parsing
+# failure for graceful exits:
+#
+#   require 'optparse'
+#
+#   OptionParser.new do |parser|
+#     parser.on('--foo') { puts 'got --foo!' }
+#   end.parse!(abort: true)
+#
+# Used:
+#
+#   $ ruby optparse-test.rb --foo
+#   got --foo!
+#   $ ruby optparse-test.rb --bar
+#   optparse-test.rb : invalid option: --bar
+#
 # === Complete example
 #
 # The following example is a complete Ruby program.  You can run it and see the
@@ -1710,7 +1728,8 @@ XXX
   # each non-option argument is yielded. When optional +into+ keyword
   # argument is provided, the parsed option values are stored there via
   # <code>[]=</code> method (so it can be Hash, or OpenStruct, or other
-  # similar object).
+  # similar object). When optional +abort+ is supplied and truthy, any
+  # +ParseError+s that occur call `OptionParser#abort` for graceful exits.
   #
   # Returns the rest of +argv+ left unparsed.
   #
@@ -1723,9 +1742,11 @@ XXX
   # Same as #order, but removes switches destructively.
   # Non-option arguments remain in +argv+.
   #
-  def order!(argv = default_argv, into: nil, **keywords, &nonopt)
+  def order!(argv = default_argv, into: nil, abort: false, **keywords, &nonopt)
     setter = ->(name, val) {into[name.to_sym] = val} if into
     parse_in_order(argv, setter, **keywords, &nonopt)
+  rescue ParseError => err
+    abort ? abort(err) : raise
   end
 
   private def parse_in_order(argv = default_argv, setter = nil, exact: require_exact, **, &nonopt)  # :nodoc:
@@ -1837,7 +1858,8 @@ XXX
   # list of non-option arguments. When optional +into+ keyword
   # argument is provided, the parsed option values are stored there via
   # <code>[]=</code> method (so it can be Hash, or OpenStruct, or other
-  # similar object).
+  # similar object). When optional +abort+ is supplied and truthy, any
+  # +ParseError+s that occur call `OptionParser#abort` for graceful exits.
   #
   def permute(*argv, **keywords)
     argv = argv[0].dup if argv.size == 1 and Array === argv[0]
@@ -1860,7 +1882,9 @@ XXX
   # POSIXLY_CORRECT is set, and in permutation mode otherwise.
   # When optional +into+ keyword argument is provided, the parsed option
   # values are stored there via <code>[]=</code> method (so it can be Hash,
-  # or OpenStruct, or other similar object).
+  # or OpenStruct, or other similar object). When optional +abort+ is supplied
+  # and truthy, any +ParseError+s that occur call `OptionParser#abort` for
+  # graceful exits.
   #
   def parse(*argv, **keywords)
     argv = argv[0].dup if argv.size == 1 and Array === argv[0]
@@ -2036,8 +2060,8 @@ XXX
   # directory ~/.options, then the basename with '.options' suffix
   # under XDG and Haiku standard places.
   #
-  # The optional +into+ keyword argument works exactly like that accepted in
-  # method #parse.
+  # The optional +into+ and +abort+ keyword arguments works exactly like that
+  # accepted in method #parse.
   #
   def load(filename = nil, **keywords)
     unless filename


### PR DESCRIPTION
Adds an `abort: true` keyword into `OptionParser#parse!` and friends. I also updated the documentation too

This is a small change but is quite useful. Example:

Old:
```ruby
require 'optparse'

OPTS = {}
OptParse.new do |op|
  op.on '--foo', '...' 
  op.on '--bar', '...' 
  
  begin
    op.parse! into: OPTS
  rescue OptParse::ParseError => err
    op.abort err
  end
end
```

Now:
```ruby
require 'optparse'

OPTS = {}
OptParse.new do |op|
  op.on '--foo', '...' 
  op.on '--bar', '...' 
  
  op.parse! into: OPTS, abort: true
end
```