### PR TITLE
Add a `reason` keyword arg to `ParseError#initialize`

### DIFF
--- a/lib/optparse.rb
+++ b/lib/optparse.rb
@@ -2249,11 +2249,11 @@ XXX
     Reason = 'parse error'
 
     # :nodoc:
-    def initialize(*args, additional: nil)
+    def initialize(*args, additional: nil, reason: nil)
       @additional = additional
       @arg0, = args
       @args = args
-      @reason = nil
+      @reason = reason
     end
 
     attr_reader :args


### PR DESCRIPTION
This adds a `reason:` keyword argument to `ParseError#initialize` for ergonomics and ease-of-use.

Before:
```rb
OptParse.accept Encoding do |arg|
  Encoding.find arg
rescue ArgumentError
  err = OptionParser::InvalidArgument.new
  err.reason = "not a valid encoding"
  raise err
end
```

Now:
```rb
OptParse.accept Encoding do |arg|
  Encoding.find arg
rescue ArgumentError
  raise OptParse::InvalidArgument.new(reason: 'not a valid encoding')
end
```